### PR TITLE
Handle database cluster initialization failure

### DIFF
--- a/run-pgadmin.sh
+++ b/run-pgadmin.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source /workspace/pgadmin-venv/bin/activate
+export PGADMIN_SETUP_EMAIL="admin@example.com"
+export PGADMIN_SETUP_PASSWORD="admin123"
+export PGADMIN_PORT=5050
+python -m pgadmin4


### PR DESCRIPTION
Install pgAdmin 4 via Python virtual environment and provide a script to run it.

This ensures pgAdmin 4 is successfully installed and runnable, addressing the user's initial problem of installation failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-80f9b862-df48-4208-a56e-8043e943aad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80f9b862-df48-4208-a56e-8043e943aad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

